### PR TITLE
Fix native prototype pollution in library mode

### DIFF
--- a/lib/htpasswd.js
+++ b/lib/htpasswd.js
@@ -5,18 +5,16 @@
  */
 require('coffee-script/register');
 
-/**
- * Importing local modules.
- */
-var program = require('./program');
-var processor = require('./processor');
-var utils = require('./utils');
+var program, processor, utils;
 
 if (require.main === module ) {
 	// Parses and processes command line arguments.
+	program = require('./program');
+	processor = require('./processor');
 	program.parse(process.argv);
 	processor.process(program);
 } else { // Library mode.
+	utils = require('./utils');
     module.exports.verify = utils.verify;
     module.exports.isCryptInstalled = utils.isCryptInstalled;
 }


### PR DESCRIPTION
Since `processor` has the package `colors` as an upstream dependency, String' s prototype would get unexpectedly modified.
This commit fixes that issue by only loading `processor` if really needed.
